### PR TITLE
Fixed latitude parsed as zero for some toolchain(libc.so)

### DIFF
--- a/src/SpeedtestConfig.c
+++ b/src/SpeedtestConfig.c
@@ -33,8 +33,8 @@ long haversineDistance(float lat1, float lon1, float lat2, float lon2)
 
 SPEEDTESTCONFIG_T *parseConfig(const char *configline)
 {
-    char lat[8];
-    char lon[8];
+    char lat[16] = {0};
+    char lon[16] = {0};
     SPEEDTESTCONFIG_T *result = malloc(sizeof(struct speedtestConfig));
     if(sscanf(configline,"%*[^\"]\"%15[^\"]\"%*[^\"]\"%15[^\"]\"%*[^\"]\"%15[^\"]\"%*[^\"]\"%255[^\"]\"",
             result->ip, lat, lon, result->isp)!=ConfigParseFieldsNumber)

--- a/src/SpeedtestConfig.h
+++ b/src/SpeedtestConfig.h
@@ -7,7 +7,7 @@
 
 typedef struct speedtestConfig
 {
-	char ip[15];
+	char ip[16];
 	float lat;
 	float lon;
 	char isp[255];


### PR DESCRIPTION
Dear mobrembski,

From the demo I see that you use %255 to hold the isp name, so the container is 256 for isp name, but you only prepare 15 bytes to hold ip(take '\0' into account you should prepare 16 Bytes for IP), and so do latitude and longitude, I think we should better use 16 Bytes to hold lat/lon.

I tested origin version in one toolchain of my product, latitude will always be parsed as 0.00. After expand local buffer I got the correct best (nearest) test server based on lat/lon calculation.

Before correction:
[2016-12-26 10:06:23.758] root@XR11500000002:/# Speeroot@XR11500000002:/# SpeedTestC
[2016-12-26 10:06:27.396] config line:<client ip="223.223.177.92" lat="39.9289" lon="116.3883" isp="Elink-space (Beijing) Technology Co,." isprating="4.0" rating="0" ispdlavg="31807" ispulavg="30613" loggedin="0" />
[2016-12-26 10:06:27.412]
[2016-12-26 10:06:27.413] parseConfig lat:[], lon:[116.3883]
[2016-12-26 10:06:27.416] Your IP: 223.223.177.92 And ISP: Elink-space (Beijing) Technology Co,.
[2016-12-26 10:06:27.422] Lat: 0.000000 Lon: 116.388298
[2016-12-26 10:08:35.525] Grabbed 5410 servers
[2016-12-26 10:08:35.885] Best Server URL: http://balikpapan.speedtest.telkom.co.id/speedtest/upload.php
[2016-12-26 10:08:35.892]    Name: Balikpapan Country: Indonesia Sponsor: PT. Telekomunikasi Indonesia Dist: 148 km
[2016-12-26 10:08:35.900] download test url:http://balikpapan.speedtest.telkom.co.id/speedtest/random750x750.jpg


After correction:
[2016-12-26 13:29:55.755] root@XR11500000002:/# SpeedTestC
[2016-12-26 13:29:57.213] config line:<client ip="223.223.177.92" lat="39.9289" lon="116.3883" isp="Elink-space (Beijing) Technology Co,." isprating="4.0" rating="0" ispdlavg="31807" ispulavg="30613" loggedin="0" />
[2016-12-26 13:29:57.230]
[2016-12-26 13:29:57.230] parseConfig lat:[39.9289], lon:[116.3883]
[2016-12-26 13:29:57.234] Your IP: 223.223.177.92 And ISP: Elink-space (Beijing) Technology Co,.
[2016-12-26 13:29:57.240] Lat: 39.928902 Lon: 116.388298
[2016-12-26 13:30:28.968] Grabbed 5418 servers
[2016-12-26 13:30:29.540] Best Server URL: http://speedtest.bmcc.com.cn/speedtest/upload.php
[2016-12-26 13:30:29.545]    Name: Beijing Country: China Sponsor: China Mobile Group Beijing Co.Ltd Dist: 1 km
[2016-12-26 13:30:29.553] download test url:http://speedtest.bmcc.com.cn/speedtest/random750x750.jpg
[2016-12-26 13:31:11.221] Bytes 1118012 downloaded in 41.67 seconds 26.20 kB/s (209.62 kb/s)
[2016-12-26 13:31:30.150] Bytes 1048576 uploaded in 18.83 seconds 54.37 kB/s (434.98 kb/s)


